### PR TITLE
Update JDGification.js

### DIFF
--- a/JDGification.js
+++ b/JDGification.js
@@ -40,7 +40,7 @@ function GetJDG() {
 // Récupère le lien vers l'image
 function GetPath(index) {
     if (alt.includes(index)) { // Version alt
-        let x = Math.random
+        let x = Math.random()
         if (x > 0.5) return ("images/JDG" + index + "alt.png");
     }
     return ("images/JDG" + index + ".png")


### PR DESCRIPTION
il manque une paranthèse sur le random pour choisir entre normal et alt, ce qui fait que les alt ne sont jamais choisis.